### PR TITLE
Bug/175650 incorrect null checks in audacia.data access specification classes

### DIFF
--- a/src/Audacia.DataAccess.EntityFrameworkCore.SqlServer/ReadDataRepository.cs
+++ b/src/Audacia.DataAccess.EntityFrameworkCore.SqlServer/ReadDataRepository.cs
@@ -142,7 +142,7 @@ public sealed class ReadDataRepository<TContext> : IReadableDataRepository, IDis
     {
         var query = ApplyIncludesAndFilter(specification);
 
-        if (specification.Order != null)
+        if (specification.Order?.OrderSteps.Count() > 0)
         {
             query = PerformOrdering(specification.Order, query);
         }

--- a/src/Audacia.DataAccess/Specifications/Filtering/AndFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/AndFilterSpecification.cs
@@ -23,12 +23,17 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="IFilterSpecification{T}"/>.</param>
     public AndFilterSpecification(IFilterSpecification<T> left, IFilterSpecification<T> right)
     {
-        if (left != null && right != null)
+        if (left is null)
         {
-            Expression = left.Expression.And(right.Expression);
+            throw new ArgumentNullException(nameof(left));
         }
 
-        Expression = _ => false;
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
+        Expression = left.Expression.And(right.Expression);
     }
 
     /// <summary>
@@ -38,12 +43,17 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="Expression{T}"/>.</param>
     public AndFilterSpecification(IFilterSpecification<T> left, Expression<Func<T, bool>> right)
     {
-        if (left != null && right != null)
+        if (left is null)
         {
-            Expression = left.Expression.And(right);
+            throw new ArgumentNullException(nameof(left));
         }
 
-        Expression = _ => false;
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
+        Expression = left.Expression.And(right);
     }
 
     /// <summary>
@@ -56,6 +66,16 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Spacing Rules", "SA1010:Opening Square Brackets Must Be Spaced Correctly", Justification = "This is the only way to create an empty array.")]
     public AndFilterSpecification(Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, params Expression<Func<T, bool>>[] additionalExpressions)
     {
+        if (left is null)
+        {
+            throw new ArgumentNullException(nameof(left));
+        }
+
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
         Expression = left.And(right);
         foreach (var expression in additionalExpressions ?? [])
         {

--- a/src/Audacia.DataAccess/Specifications/Filtering/AndFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/AndFilterSpecification.cs
@@ -23,15 +23,8 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="IFilterSpecification{T}"/>.</param>
     public AndFilterSpecification(IFilterSpecification<T> left, IFilterSpecification<T> right)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.Expression.And(right.Expression);
     }
@@ -43,15 +36,8 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="Expression{T}"/>.</param>
     public AndFilterSpecification(IFilterSpecification<T> left, Expression<Func<T, bool>> right)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.Expression.And(right);
     }
@@ -66,15 +52,8 @@ public class AndFilterSpecification<T> : IFilterSpecification<T>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Spacing Rules", "SA1010:Opening Square Brackets Must Be Spaced Correctly", Justification = "This is the only way to create an empty array.")]
     public AndFilterSpecification(Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, params Expression<Func<T, bool>>[] additionalExpressions)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.And(right);
         foreach (var expression in additionalExpressions ?? [])

--- a/src/Audacia.DataAccess/Specifications/Filtering/NotFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/NotFilterSpecification.cs
@@ -21,11 +21,11 @@ public class NotFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="specificationToNegate">Instance of <see cref="IFilterSpecification{T}"/>.</param>
     public NotFilterSpecification(IFilterSpecification<T> specificationToNegate)
     {
-        if (specificationToNegate != null) 
+        if (specificationToNegate is null)
         {
-            Expression = specificationToNegate.Expression.Not();
+            throw new ArgumentNullException(nameof(specificationToNegate));
         }
 
-        Expression = _ => false;
+        Expression = specificationToNegate.Expression.Not();
     }
 }

--- a/src/Audacia.DataAccess/Specifications/Filtering/NotFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/NotFilterSpecification.cs
@@ -21,10 +21,7 @@ public class NotFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="specificationToNegate">Instance of <see cref="IFilterSpecification{T}"/>.</param>
     public NotFilterSpecification(IFilterSpecification<T> specificationToNegate)
     {
-        if (specificationToNegate is null)
-        {
-            throw new ArgumentNullException(nameof(specificationToNegate));
-        }
+        ArgumentNullException.ThrowIfNull(specificationToNegate, nameof(specificationToNegate));
 
         Expression = specificationToNegate.Expression.Not();
     }

--- a/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
@@ -23,12 +23,17 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="IFilterSpecification{T}"/>.</param>
     public OrFilterSpecification(IFilterSpecification<T> left, IFilterSpecification<T> right)
     {
-        if (left != null && right != null)
+        if (left is null)
         {
-            Expression = left.Expression.Or(right.Expression);
+            throw new ArgumentNullException(nameof(left));
         }
 
-        Expression = _ => false;
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
+        Expression = left.Expression.Or(right.Expression);
     }
 
     /// <summary>
@@ -38,12 +43,17 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="Expression{T}"/>.</param>
     public OrFilterSpecification(IFilterSpecification<T> left, Expression<Func<T, bool>> right)
     {
-        if (left != null) 
+        if (left is null)
         {
-            Expression = left.Expression.Or(right);
+            throw new ArgumentNullException(nameof(left));
         }
-        
-        Expression = _ => false;
+
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
+        Expression = left.Expression.Or(right);
     }
 
     /// <summary>
@@ -56,6 +66,16 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Spacing Rules", "SA1010:Opening Square Brackets Must Be Spaced Correctly", Justification = "This is the only way to create an empty array.")]
     public OrFilterSpecification(Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, params Expression<Func<T, bool>>[] additionalExpressions)
     {
+        if (left is null)
+        {
+            throw new ArgumentNullException(nameof(left));
+        }
+
+        if (right is null)
+        {
+            throw new ArgumentNullException(nameof(right));
+        }
+
         Expression = left.Or(right);
         foreach (var expression in additionalExpressions ?? [])
         {

--- a/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
@@ -43,15 +43,8 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="Expression{T}"/>.</param>
     public OrFilterSpecification(IFilterSpecification<T> left, Expression<Func<T, bool>> right)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.Expression.Or(right);
     }
@@ -66,15 +59,8 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Spacing Rules", "SA1010:Opening Square Brackets Must Be Spaced Correctly", Justification = "This is the only way to create an empty array.")]
     public OrFilterSpecification(Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, params Expression<Func<T, bool>>[] additionalExpressions)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.Or(right);
         foreach (var expression in additionalExpressions ?? [])

--- a/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Filtering/OrFilterSpecification.cs
@@ -23,15 +23,8 @@ public class OrFilterSpecification<T> : IFilterSpecification<T>
     /// <param name="right">Right part of the Expression <see cref="IFilterSpecification{T}"/>.</param>
     public OrFilterSpecification(IFilterSpecification<T> left, IFilterSpecification<T> right)
     {
-        if (left is null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
-
-        if (right is null)
-        {
-            throw new ArgumentNullException(nameof(right));
-        }
+        ArgumentNullException.ThrowIfNull(left, nameof(left));
+        ArgumentNullException.ThrowIfNull(right, nameof(right));
 
         Expression = left.Expression.Or(right.Expression);
     }

--- a/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
@@ -17,12 +17,12 @@ public class DynamicIncludeSpecification<T> : IIncludeSpecification<T>
     /// <param name="includeAction">Instance of <see cref="IBuildableIncludeSpecification{T}"/>. </param>
     public DynamicIncludeSpecification(Action<IBuildableIncludeSpecification<T>> includeAction)
     {
-        _wrappedSpecification = IncludeSpecification<T>.CreateInternal();
-
-        if (includeAction != null)
+        if (includeAction is null)
         {
-            includeAction(_wrappedSpecification);
+            throw new ArgumentNullException(nameof(includeAction));
         }
+
+        _wrappedSpecification = IncludeSpecification<T>.CreateInternal();
     }
 
     /// <summary>

--- a/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
@@ -23,6 +23,7 @@ public class DynamicIncludeSpecification<T> : IIncludeSpecification<T>
         }
 
         _wrappedSpecification = IncludeSpecification<T>.CreateInternal();
+        includeAction(_wrappedSpecification);
     }
 
     /// <summary>

--- a/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Including/DynamicIncludeSpecification.cs
@@ -17,10 +17,7 @@ public class DynamicIncludeSpecification<T> : IIncludeSpecification<T>
     /// <param name="includeAction">Instance of <see cref="IBuildableIncludeSpecification{T}"/>. </param>
     public DynamicIncludeSpecification(Action<IBuildableIncludeSpecification<T>> includeAction)
     {
-        if (includeAction is null)
-        {
-            throw new ArgumentNullException(nameof(includeAction));
-        }
+        ArgumentNullException.ThrowIfNull(includeAction, nameof(includeAction));
 
         _wrappedSpecification = IncludeSpecification<T>.CreateInternal();
         includeAction(_wrappedSpecification);

--- a/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
@@ -23,6 +23,7 @@ public class DynamicOrderSpecification<T> : IOrderSpecification<T>
         }
 
         _wrappedSpecification = OrderSpecification<T>.CreateInternal();
+        orderAction(_wrappedSpecification);
     }
 
     /// <summary>

--- a/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
@@ -17,10 +17,7 @@ public class DynamicOrderSpecification<T> : IOrderSpecification<T>
     /// <param name="orderAction">Instance of <see cref="IBuildableOrderSpecification{T}"/>.</param>
     public DynamicOrderSpecification(Action<IBuildableOrderSpecification<T>> orderAction)
     {
-        if (orderAction is null)
-        {
-            throw new ArgumentNullException(nameof(orderAction));
-        }
+        ArgumentNullException.ThrowIfNull(orderAction, nameof(orderAction));
 
         _wrappedSpecification = OrderSpecification<T>.CreateInternal();
         orderAction(_wrappedSpecification);

--- a/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Ordering/DynamicOrderSpecification.cs
@@ -17,12 +17,12 @@ public class DynamicOrderSpecification<T> : IOrderSpecification<T>
     /// <param name="orderAction">Instance of <see cref="IBuildableOrderSpecification{T}"/>.</param>
     public DynamicOrderSpecification(Action<IBuildableOrderSpecification<T>> orderAction)
     {
-        _wrappedSpecification = OrderSpecification<T>.CreateInternal();
-
-        if (orderAction != null)
+        if (orderAction is null)
         {
-            orderAction(_wrappedSpecification);
+            throw new ArgumentNullException(nameof(orderAction));
         }
+
+        _wrappedSpecification = OrderSpecification<T>.CreateInternal();
     }
 
     /// <summary>

--- a/src/Audacia.DataAccess/Specifications/Ordering/OrderableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Ordering/OrderableQuerySpecification.cs
@@ -33,10 +33,7 @@ public class OrderableQuerySpecification<T> : IOrderableQuerySpecification<T>
     /// <param name="orderSpecification"><see cref="IOrderSpecification{T}"/>.</param>
     public OrderableQuerySpecification(IOrderSpecification<T> orderSpecification)
     {
-        if (orderSpecification is null)
-        {
-            throw new ArgumentNullException(nameof(orderSpecification));
-        }
+        ArgumentNullException.ThrowIfNull(orderSpecification, nameof(orderSpecification));
 
         Order = orderSpecification;
     }
@@ -48,15 +45,8 @@ public class OrderableQuerySpecification<T> : IOrderableQuerySpecification<T>
     /// <param name="orderSpecification">Instance of <see cref="IOrderSpecification{T}"/>.</param>
     public OrderableQuerySpecification(IQuerySpecification<T> buildFrom, IOrderSpecification<T> orderSpecification)
     {
-        if (orderSpecification is null)
-        {
-            throw new ArgumentNullException(nameof(orderSpecification));
-        }
-
-        if (buildFrom is null)
-        {
-            throw new ArgumentNullException(nameof(buildFrom));
-        }
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
+        ArgumentNullException.ThrowIfNull(orderSpecification, nameof(orderSpecification));
 
         Filter = buildFrom.Filter;
         Include = buildFrom.Include;
@@ -102,12 +92,12 @@ public class OrderableQuerySpecification<T, TResult> : IOrderableQuerySpecificat
         IProjectableQuerySpecification<T, TResult> buildFrom,
         IOrderSpecification<TResult> orderSpecification)
     {
-        if (buildFrom != null)
-        {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
-            Projection = buildFrom.Projection;
-        }
+        ArgumentNullException.ThrowIfNull(orderSpecification, nameof(orderSpecification));
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
+        Projection = buildFrom.Projection;
 
         Order = orderSpecification;
     }

--- a/src/Audacia.DataAccess/Specifications/Ordering/OrderableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Ordering/OrderableQuerySpecification.cs
@@ -1,4 +1,5 @@
-﻿using Audacia.DataAccess.Specifications.Filtering;
+﻿using System;
+using Audacia.DataAccess.Specifications.Filtering;
 using Audacia.DataAccess.Specifications.Including;
 using Audacia.DataAccess.Specifications.Projection;
 
@@ -32,10 +33,12 @@ public class OrderableQuerySpecification<T> : IOrderableQuerySpecification<T>
     /// <param name="orderSpecification"><see cref="IOrderSpecification{T}"/>.</param>
     public OrderableQuerySpecification(IOrderSpecification<T> orderSpecification)
     {
-        if (orderSpecification != null)
+        if (orderSpecification is null)
         {
-            Order = orderSpecification;
+            throw new ArgumentNullException(nameof(orderSpecification));
         }
+
+        Order = orderSpecification;
     }
 
     /// <summary>
@@ -45,11 +48,18 @@ public class OrderableQuerySpecification<T> : IOrderableQuerySpecification<T>
     /// <param name="orderSpecification">Instance of <see cref="IOrderSpecification{T}"/>.</param>
     public OrderableQuerySpecification(IQuerySpecification<T> buildFrom, IOrderSpecification<T> orderSpecification)
     {
-        if (buildFrom != null)
+        if (orderSpecification is null)
         {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
+            throw new ArgumentNullException(nameof(orderSpecification));
         }
+
+        if (buildFrom is null)
+        {
+            throw new ArgumentNullException(nameof(buildFrom));
+        }
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
 
         Order = orderSpecification;
     }

--- a/src/Audacia.DataAccess/Specifications/Paging/PageableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Paging/PageableQuerySpecification.cs
@@ -1,4 +1,5 @@
-﻿using Audacia.Core;
+﻿using System;
+using Audacia.Core;
 using Audacia.DataAccess.Specifications.Filtering;
 using Audacia.DataAccess.Specifications.Including;
 using Audacia.DataAccess.Specifications.Ordering;
@@ -43,12 +44,19 @@ public class PageableQuerySpecification<T> : IPageableQuerySpecification<T> wher
         IOrderableQuerySpecification<T> buildFrom,
         PagingRequest sortablePagingRequest)
     {
-        if (buildFrom != null)
+        if (sortablePagingRequest is null)
         {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
-            Order = buildFrom.Order;
+            throw new ArgumentNullException(nameof(sortablePagingRequest));
         }
+
+        if (buildFrom is null)
+        {
+            throw new ArgumentNullException(nameof(buildFrom));
+        }
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
+        Order = buildFrom.Order;
 
         PagingRequest = sortablePagingRequest;
     }

--- a/src/Audacia.DataAccess/Specifications/Paging/PageableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Paging/PageableQuerySpecification.cs
@@ -44,15 +44,8 @@ public class PageableQuerySpecification<T> : IPageableQuerySpecification<T> wher
         IOrderableQuerySpecification<T> buildFrom,
         PagingRequest sortablePagingRequest)
     {
-        if (sortablePagingRequest is null)
-        {
-            throw new ArgumentNullException(nameof(sortablePagingRequest));
-        }
-
-        if (buildFrom is null)
-        {
-            throw new ArgumentNullException(nameof(buildFrom));
-        }
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
+        ArgumentNullException.ThrowIfNull(sortablePagingRequest, nameof(sortablePagingRequest));
 
         Filter = buildFrom.Filter;
         Include = buildFrom.Include;
@@ -105,13 +98,13 @@ public class PageableQuerySpecification<T, TResult> : IPageableQuerySpecificatio
         IOrderableQuerySpecification<T, TResult> buildFrom,
         PagingRequest sortablePagingRequest)
     {
-        if (buildFrom != null)
-        {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
-            Projection = buildFrom.Projection;
-            Order = buildFrom.Order;
-        }
+        ArgumentNullException.ThrowIfNull(sortablePagingRequest, nameof(sortablePagingRequest));
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
+        Projection = buildFrom.Projection;
+        Order = buildFrom.Order;
 
         PagingRequest = sortablePagingRequest;
     }

--- a/src/Audacia.DataAccess/Specifications/Paging/Sorting/SortablePageableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Paging/Sorting/SortablePageableQuerySpecification.cs
@@ -35,6 +35,8 @@ public class SortablePageableQuerySpecification<T> : ISortablePageableQuerySpeci
     /// <param name="sortablePagingRequest">Instance of <see cref="SortablePagingRequest"/>.</param>
     public SortablePageableQuerySpecification(SortablePagingRequest sortablePagingRequest)
     {
+        ArgumentNullException.ThrowIfNull(sortablePagingRequest, nameof(sortablePagingRequest));
+
         SortablePagingRequest = sortablePagingRequest;
     }
 
@@ -45,10 +47,8 @@ public class SortablePageableQuerySpecification<T> : ISortablePageableQuerySpeci
     /// <param name="sortablePagingRequest">Instance of <see cref="SortablePagingRequest"/>.</param>
     public SortablePageableQuerySpecification(IQuerySpecification<T> buildFrom, SortablePagingRequest sortablePagingRequest)
     {
-        if (buildFrom is null)
-        {
-            throw new ArgumentNullException(nameof(buildFrom));
-        }
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
+        ArgumentNullException.ThrowIfNull(sortablePagingRequest, nameof(sortablePagingRequest));
 
         Filter = buildFrom.Filter;
         Include = buildFrom.Include;
@@ -102,10 +102,7 @@ public class SortablePageableQuerySpecification<T, TResult> : ISortablePageableQ
     /// <param name="sortablePagingRequest">Instance of <see cref="SortablePagingRequest"/>.</param>
     public SortablePageableQuerySpecification(IProjectableQuerySpecification<T, TResult> buildFrom, SortablePagingRequest sortablePagingRequest)
     {
-        if (buildFrom is null)
-        {
-            throw new ArgumentNullException(nameof(buildFrom));
-        }
+        ArgumentNullException.ThrowIfNull(buildFrom, nameof(buildFrom));
 
         Filter = buildFrom.Filter;
         Include = buildFrom.Include;

--- a/src/Audacia.DataAccess/Specifications/Paging/Sorting/SortablePageableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Paging/Sorting/SortablePageableQuerySpecification.cs
@@ -1,4 +1,5 @@
-﻿using Audacia.Core;
+﻿using System;
+using Audacia.Core;
 using Audacia.DataAccess.Specifications.Filtering;
 using Audacia.DataAccess.Specifications.Including;
 using Audacia.DataAccess.Specifications.Projection;
@@ -44,11 +45,13 @@ public class SortablePageableQuerySpecification<T> : ISortablePageableQuerySpeci
     /// <param name="sortablePagingRequest">Instance of <see cref="SortablePagingRequest"/>.</param>
     public SortablePageableQuerySpecification(IQuerySpecification<T> buildFrom, SortablePagingRequest sortablePagingRequest)
     {
-        if (buildFrom != null)
+        if (buildFrom is null)
         {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
+            throw new ArgumentNullException(nameof(buildFrom));
         }
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
 
         SortablePagingRequest = sortablePagingRequest;
     }
@@ -99,12 +102,14 @@ public class SortablePageableQuerySpecification<T, TResult> : ISortablePageableQ
     /// <param name="sortablePagingRequest">Instance of <see cref="SortablePagingRequest"/>.</param>
     public SortablePageableQuerySpecification(IProjectableQuerySpecification<T, TResult> buildFrom, SortablePagingRequest sortablePagingRequest)
     {
-        if (buildFrom != null)
+        if (buildFrom is null)
         {
-            Filter = buildFrom.Filter;
-            Include = buildFrom.Include;
-            Projection = buildFrom.Projection;
+            throw new ArgumentNullException(nameof(buildFrom));
         }
+
+        Filter = buildFrom.Filter;
+        Include = buildFrom.Include;
+        Projection = buildFrom.Projection;
 
         SortablePagingRequest = sortablePagingRequest;
     }

--- a/src/Audacia.DataAccess/Specifications/Projection/ProjectableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Projection/ProjectableQuerySpecification.cs
@@ -79,11 +79,13 @@ public class ProjectableQuerySpecification<T, TResult> : IProjectableQuerySpecif
         IQuerySpecification<T> startFrom,
         IProjectionSpecification<T, TResult> projectionSpecification)
     {
-        if (startFrom != null)
+        if (startFrom is null)
         {
-            Filter = startFrom.Filter;
-            Include = startFrom.Include;
+            throw new ArgumentNullException(nameof(startFrom));
         }
+
+        Filter = startFrom.Filter;
+        Include = startFrom.Include;
 
         Projection = projectionSpecification;
     }

--- a/src/Audacia.DataAccess/Specifications/Projection/ProjectableQuerySpecification.cs
+++ b/src/Audacia.DataAccess/Specifications/Projection/ProjectableQuerySpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using Audacia.Core;
 using Audacia.DataAccess.Specifications.Filtering;
 using Audacia.DataAccess.Specifications.Including;
 
@@ -67,6 +68,8 @@ public class ProjectableQuerySpecification<T, TResult> : IProjectableQuerySpecif
     /// <param name="projectionSpecification">Instance of projectionSpecification.</param>
     public ProjectableQuerySpecification(IProjectionSpecification<T, TResult> projectionSpecification)
     {
+        ArgumentNullException.ThrowIfNull(projectionSpecification, nameof(projectionSpecification));
+
         Projection = projectionSpecification;
     }
 
@@ -79,10 +82,8 @@ public class ProjectableQuerySpecification<T, TResult> : IProjectableQuerySpecif
         IQuerySpecification<T> startFrom,
         IProjectionSpecification<T, TResult> projectionSpecification)
     {
-        if (startFrom is null)
-        {
-            throw new ArgumentNullException(nameof(startFrom));
-        }
+        ArgumentNullException.ThrowIfNull(projectionSpecification, nameof(projectionSpecification));
+        ArgumentNullException.ThrowIfNull(startFrom, nameof(startFrom));
 
         Filter = startFrom.Filter;
         Include = startFrom.Include;


### PR DESCRIPTION
Updated the areas listed on the bug to throw an Argument Null Exception rather than continue on null.
https://dev.azure.com/audacia/Audacia/_workitems/edit/175650

Unit tests ran to confirm.

Note: adding the argument null exception to DynamicIncludeSpecification was on the bug list. 
The original implementation looked a bit like the includeAction being checked could be null, and just adding the order steps would be optional if not null. I'm not sure if this was the original intent but it does cause problems further down the line if it null as no order steps are added and the dequeue step can't handle that. Therefore I have enforced it not being null with the argument exception as requested on the bug.

